### PR TITLE
#107 Used parameters are listed in the result to improve the transparency of the causal discovery result.

### DIFF
--- a/R/tetradrunner.R
+++ b/R/tetradrunner.R
@@ -218,13 +218,15 @@ tetradrunner <- function(algoId, dataType, df = NULL, dfs = NULL, testId = NULL,
 		tetradrunner$graph <- tetrad_graph
 
 		V <- extractTetradNodes(tetrad_graph)
-
 		tetradrunner$nodes <- V
 
 		# extract edges
 		tetradrunner_edges <- extractTetradEdges(tetrad_graph)
+		tetradrunner$edges <- tetradrunner_edges
 
-		tetradrunner$edges <- tetradrunner_edges        
+		u_params <- .jcall(parameters_instance, "S", "toString")
+		used_params <- unlist(strsplit(gsub("\r", "", u_params, fixed = T), "\n", T))
+		tetradrunner$usedParameters <- used_params
 	}
 
 	return(tetradrunner)


### PR DESCRIPTION
I used delimiters to vectorize the String of parameters.
If the tetrad specs changes, the code need to be modified.

It seems to be reasonable way to check. we don't have to use excel or additional codes. 
```
> ls.tetrad$usedParameters
[1] "numberResampling = 0"        "samplePrior = 10"            "structurePrior = 1"          "faithfulnessAssumed = false"
[5] "verbose = false"             "maxDegree = 100"             "symmetricFirstStep = true"   "printStream = "  
```