### PR TITLE
#106 Fixed. Loading time becomes over 600x faster when alarm dataset is used.

### DIFF
--- a/R/tetrad_utils.R
+++ b/R/tetrad_utils.R
@@ -314,20 +314,22 @@ loadDiscreteData <- function(df){
 
 	for (i in 1:length(node_names)){
 		nodname <- .jnew("java/lang/String", node_names[i])
-		cat("node_names: ", node_names[i],"\n")
+#		cat("node_names: ", node_names[i],"\n")
 		cate <- unique(df[[node_names[i]]])
 		cate <- sort(cate)
-		cat("value: ")
-		print(cate)
-		cat("\n")
+#   cat("value: ")
+#   print(cate)
+#   cat("\n")
 		cate_list <- .jnew("java/util/ArrayList")
 		for(j in 1:length(cate)){
-			cate_list$add(as.character(cate[j]))
+#			cate_list$add(as.character(cate[j]))
+		  .jcall(cate_list, "Z", "add", .jcast(.jnew("java/lang/String", as.character(cate[j])), "java/lang/Object"))
 		}
 		cate_list <- .jcast(cate_list, "java/util/List")
 		nodi <- .jnew("edu/cmu/tetrad/data/DiscreteVariable", 
 						nodname, cate_list)
-		node_list$add(nodi)
+#		node_list$add(nodi)
+		.jcall(node_list, "Z", "add", .jcast(nodi, "java/lang/Object"))
 
 		# Substitute a new categorial value
 		c.cate <- cate

--- a/R/tetrad_utils.R
+++ b/R/tetrad_utils.R
@@ -308,6 +308,10 @@ loadContinuousData <- function(df){
 loadDiscreteData <- function(df){
 	node_names <- colnames(df)
 	node_list <- .jnew("java/util/ArrayList")
+
+	mat_dataset <- matrix(0L, ncol = ncol(df), nrow = nrow(df))
+	colnames(mat_dataset) <- node_names
+
 	for (i in 1:length(node_names)){
 		nodname <- .jnew("java/lang/String", node_names[i])
 		cat("node_names: ", node_names[i],"\n")
@@ -326,15 +330,13 @@ loadDiscreteData <- function(df){
 		node_list$add(nodi)
 
 		# Substitute a new categorial value
-		cate <- data.frame(cate)
-		new_col <- sapply(df[,i],function(x,cate) 
-					as.integer(which(cate[,1] == x)),cate=cate)
-		new_col = as.integer(new_col - 1)
-		df[,i] <- (data.frame(new_col))[,1]
+		c.cate <- cate
+		c.new.col <- as.integer(factor(df[,i], levels = cate))
+		c.new.col <- c.new.col - 1L
+		mat_dataset[,i] <- c.new.col
 	}
 	node_list <- .jcast(node_list, "java/util/List")
-	mt <- as.matrix(df)
-	mat <- .jarray(t(mt), dispatch=TRUE)
+	mat <- .jarray(t(mat_dataset), dispatch=TRUE)
 	data <- .jnew("edu/cmu/tetrad/data/VerticalIntDataBox", mat)
 	data <- .jcast(data, "edu/cmu/tetrad/data/DataBox")
 	boxData <- .jnew("edu/cmu/tetrad/data/BoxDataSet", data, node_list)

--- a/R/tetrad_utils.R
+++ b/R/tetrad_utils.R
@@ -199,8 +199,8 @@ rCovMatrix2TetradCovMatrix <- function(covmat, node_names, sample_size){
 ############################################################
 # extract nodes from Tetrad graph result
 extractTetradNodes <- function(resultGraph){
-    nods <- resultGraph$getNodes()
-	V <- sapply(as.list(nods), with, toString())
+    nods <- resultGraph$getNodeNames()
+    V <- sapply(as.list(nods), .jcall, "S", "toString")
     return(V)
 }
 
@@ -208,11 +208,11 @@ extractTetradNodes <- function(resultGraph){
 # extract edges from Tetrad graph result
 extractTetradEdges <- function(resultGraph){
     eds <- resultGraph$getEdges()
-    fgs_edges <- c()
+    edges <- c()
     if(!is.null(eds)){
-	   fgs_edges <- sapply(as.list(eds), .jrcall, "toString")
+        edges <- sapply(as.list(eds), .jcall, "S", "toString")
     }
-    return(fgs_edges)
+    return(edges)
 }
 
 ############################################################


### PR DESCRIPTION
Hi developers,
loading process: ca. 60 secs to 0.3 secs.

I am confident to improve them, avoiding possible side effects.
But I appreciate if developer/contributors could review the codes.

Major issue was sapply function for modify data at every sample.
Other time-cosuming process can be improved by the replacement of $.

As long as you know well about Java TETRAD code, it is easy to replace them.
I am limited knowledge on Java code. so I feel like somebody to extend this idea...

in [rJava help,](http://www.rforge.net/doc/packages/rJava/accessOp.html)
> rJava provides two levels of API: low-level JNI-API in the form of [.jcall](http://www.rforge.net/doc/rJava/help/.jcall.html) function and high-level reflection API based on the $ operator. The former is very fast, but inflexible. The latter is a convenient way to use Java-like programming at the cost of performance. The reflection API is build around the $ operator on [jobjRef-class](http://www.rforge.net/doc/rJava/help/jobjRef-class.html) objects that allows to access Java attributes and call object methods.
> 
> (cut)
> 
> names and .DollarNames returns all fields and methods associated with the object. Method names are followed by ( or () depending on arity. This use of names is mainly useful for code completion, it is not intended to be used programmatically.
> 
> This is just a convenience API. Internally all calls are mapped into [.jcall](http://www.rforge.net/doc/rJava/help/.jcall.html) calls, therefore the calling conventions and returning objects use the same rules. For time-critical Java calls [.jcall](http://www.rforge.net/doc/rJava/help/.jcall.html) should be used directly.

![image](https://user-images.githubusercontent.com/89838961/195496781-45f99916-ef0e-4fc3-ae8c-d45c79463c9e.png)

